### PR TITLE
Rails 5 compatibility

### DIFF
--- a/lib/heroku-deflater/serve_zipped_assets.rb
+++ b/lib/heroku-deflater/serve_zipped_assets.rb
@@ -12,6 +12,7 @@ module HerokuDeflater
     def initialize(app, root, assets_path, cache_control=nil)
       @app = app
       @assets_path = assets_path.chomp('/') + '/'
+      cache_control = { headers: { 'Cache-Control': cache_control } } if Rails::VERSION::MAJOR >= 5 && cache_control.is_a? String
       @file_handler = ActionDispatch::FileHandler.new(root, cache_control)
     end
 


### PR DESCRIPTION
This is more a request for comments and a general discussion than an actual pull-request. 

This is the patch that I'm using for Rails 5 compatability, but there might be better ways. So let's explore. 

Rails 5 has changed method signature for `ActionDispatch::FileHandler` to take a hash of headers and not a single string. 

```ruby
module ActionDispatch
  class FileHandler
    def initialize(root, index: 'index', headers: {})
      # ... 
    end
end