### PR TITLE
cache control header changes to public_file_server in Rails 5

### DIFF
--- a/lib/heroku-deflater/railtie.rb
+++ b/lib/heroku-deflater/railtie.rb
@@ -12,9 +12,17 @@ module HerokuDeflater
     end
 
     # Set default Cache-Control headers to one week.
+    CACHE_CONTROL_HEADER = 'public, max-age=604800'.freeze
+
     # The configuration block in config/application.rb overrides this.
-    config.before_configuration do |app|
-      app.config.static_cache_control = 'public, max-age=604800'
+    if Rails.version >= '5.0.0'.freeze
+      config.before_configuration do |app|
+        app.config.public_file_server.headers = { 'Cache-Control' => CACHE_CONTROL_HEADER }
+      end
+    else
+      config.before_configuration do |app|
+        app.config.static_cache_control = CACHE_CONTROL_HEADER
+      end
     end
   end
 end


### PR DESCRIPTION
Update for Rails 5 to fix following warning:

```
DEPRECATION WARNING: `static_cache_control` is deprecated and will be removed in Rails 5.1.
Please use
`config.public_file_server.headers = { 'Cache-Control' => 'public, max-age=604800' }`
instead.
(called from block in <class:Railtie> at
/app/vendor/bundle/ruby/2.3.0/gems/heroku-deflater-0.6.2/lib/heroku-deflater/railtie.rb:17)
```