### PR TITLE
Remove deprecated warning

### DIFF
--- a/lib/heroku-deflater/cache_control_manager.rb
+++ b/lib/heroku-deflater/cache_control_manager.rb
@@ -1,6 +1,6 @@
 module HerokuDeflater
   class CacheControlManager
-    attr_reader :app,:max_age
+    attr_reader :app, :max_age
 
     def initialize(app)
       @app = app
@@ -10,7 +10,7 @@ module HerokuDeflater
       @max_age = max_age
       if rails_version_5?
         app.config.public_file_server.headers ||= {}
-        app.config.public_file_server[:headers] = {'Cache-Control' => cache_control}
+        app.config.public_file_server.headers['Cache-Control'] = cache_control
       else
         app.config.static_cache_control = cache_control
       end
@@ -31,7 +31,7 @@ module HerokuDeflater
     end
 
     def cache_control
-      "public, max-age=#{max_age}"
+      @_cache_control ||= "public, max-age=#{max_age}"
     end
   end
 end

--- a/lib/heroku-deflater/cache_control_manager.rb
+++ b/lib/heroku-deflater/cache_control_manager.rb
@@ -1,0 +1,37 @@
+module HerokuDeflater
+  class CacheControlManager
+    attr_reader :app,:max_age
+
+    def initialize(app)
+      @app = app
+    end
+
+    def setup_max_age(max_age)
+      @max_age = max_age
+      if rails_version_5?
+        app.config.public_file_server.headers ||= {}
+        app.config.public_file_server[:headers] = {'Cache-Control' => cache_control}
+      else
+        app.config.static_cache_control = cache_control
+      end
+    end
+
+    def cache_control_headers
+      if rails_version_5?
+        { headers: { 'Cache-Control' => cache_control } }
+      else
+        cache_control
+      end
+    end
+
+    private
+
+    def rails_version_5?
+      Rails::VERSION::MAJOR >= 5
+    end
+
+    def cache_control
+      "public, max-age=#{max_age}"
+    end
+  end
+end

--- a/lib/heroku-deflater/railtie.rb
+++ b/lib/heroku-deflater/railtie.rb
@@ -1,6 +1,7 @@
 require 'rack/deflater'
 require 'heroku-deflater/skip_binary'
 require 'heroku-deflater/serve_zipped_assets'
+require 'heroku-deflater/cache_control_manager'
 
 module HerokuDeflater
   class Railtie < Rails::Railtie
@@ -8,13 +9,18 @@ module HerokuDeflater
       app.middleware.insert_before ActionDispatch::Static, Rack::Deflater
       app.middleware.insert_before ActionDispatch::Static, HerokuDeflater::SkipBinary
       app.middleware.insert_before Rack::Deflater, HerokuDeflater::ServeZippedAssets,
-        app.paths['public'].first, app.config.assets.prefix, app.config.static_cache_control
+        app.paths['public'].first, app.config.assets.prefix, self.class.cache_control_manager(app)
     end
 
     # Set default Cache-Control headers to one week.
     # The configuration block in config/application.rb overrides this.
     config.before_configuration do |app|
-      app.config.static_cache_control = 'public, max-age=604800'
+      cache_control = cache_control_manager(app)
+      cache_control.setup_max_age(64800)
+    end
+
+    def self.cache_control_manager(app)
+      @_cache_control_manager ||= CacheControlManager.new(app)
     end
   end
 end

--- a/lib/heroku-deflater/serve_zipped_assets.rb
+++ b/lib/heroku-deflater/serve_zipped_assets.rb
@@ -9,11 +9,10 @@ require 'action_dispatch/middleware/static'
 
 module HerokuDeflater
   class ServeZippedAssets
-    def initialize(app, root, assets_path, cache_control=nil)
+    def initialize(app, root, assets_path, cache_control_manager)
       @app = app
       @assets_path = assets_path.chomp('/') + '/'
-      cache_control = {headers: {'Cache-Control' => cache_control}} if Rails::VERSION::MAJOR >= 5 && cache_control.is_a?(String)
-      @file_handler = ActionDispatch::FileHandler.new(root, cache_control)
+      @file_handler = ActionDispatch::FileHandler.new(root, cache_control_manager.cache_control_headers)
     end
 
     def call(env)

--- a/spec/cache_control_manager_spec.rb
+++ b/spec/cache_control_manager_spec.rb
@@ -1,0 +1,63 @@
+require 'heroku-deflater/cache_control_manager'
+require 'rails'
+
+describe HerokuDeflater::CacheControlManager do
+  class Rails5App
+    def config
+      @_config ||= Config.new
+    end
+
+    class Config
+      attr_accessor :headers
+
+      def initialize
+        @headers = {}
+      end
+
+      def public_file_server
+        self
+      end
+    end
+  end
+
+  class Rails4App < Rails::Application
+  end
+
+  context 'Rails 4.x and below' do
+    def rails_4_app
+      @_rails_4_app ||= Rails4App.new
+    end
+
+    before { described_class.any_instance.stub(:rails_version_5?).and_return(false) }
+    subject { described_class.new(rails_4_app) }
+
+    it 'sets max age for static_cache_control config option' do
+      subject.setup_max_age(64800)
+      rails_4_app.config.static_cache_control.should eq('public, max-age=64800')
+    end
+
+    it 'cache_control_headers returns cache control option' do
+      subject.setup_max_age(64800)
+      subject.cache_control_headers.should eq('public, max-age=64800')
+    end
+  end
+
+  context 'Rails 5' do
+    def rails_5_app
+      @_rails_5_app ||= Rails5App.new
+    end
+
+    before { described_class.any_instance.stub(:rails_version_5?).and_return(true) }
+    subject { described_class.new(rails_5_app) }
+
+    it 'sets max age for public_file_server config option' do
+      subject.setup_max_age(64800)
+      rails_5_app.config.public_file_server.headers['Cache-Control'].should eq('public, max-age=64800')
+    end
+
+    it 'cache_control_headers returns hash cache control headers' do
+      subject.setup_max_age(64800)
+      subject.cache_control_headers.should eq(headers: { 'Cache-Control' =>'public, max-age=64800'})
+    end
+  end
+end

--- a/spec/serve_zipped_assets_spec.rb
+++ b/spec/serve_zipped_assets_spec.rb
@@ -1,6 +1,7 @@
 require 'rack/mock'
 require 'rack/static'
 require 'heroku-deflater/serve_zipped_assets'
+require 'heroku-deflater/cache_control_manager'
 
 describe HerokuDeflater::ServeZippedAssets do
   def process(path, accept_encoding = 'compress, gzip, deflate')
@@ -12,9 +13,10 @@ describe HerokuDeflater::ServeZippedAssets do
   def app
     @app ||= begin
       root_path = File.expand_path('../fixtures', __FILE__)
-      cache_control = 'public, max-age=86400'
+      cache_control_manager = HerokuDeflater::CacheControlManager.new(nil)
+      cache_control_manager.stub(:cache_control_headers) { 'public, max-age=86400' }
       mock = lambda { |env| [404, {'X-Cascade' => 'pass'}, []] }
-      described_class.new(mock, root_path, '/assets', cache_control)
+      described_class.new(mock, root_path, '/assets', cache_control_manager)
     end
   end
 


### PR DESCRIPTION
`static_cache_control` is deprecated and will be removed in Rails 5.1. Added CacheControlManager for setup cache options for different rails version.  