### PR TITLE
Correct default max-age from 64,800 to 604,800 (18 hours -> 1 week)

### DIFF
--- a/lib/heroku-deflater/railtie.rb
+++ b/lib/heroku-deflater/railtie.rb
@@ -16,7 +16,7 @@ module HerokuDeflater
     # The configuration block in config/application.rb overrides this.
     config.before_configuration do |app|
       cache_control = cache_control_manager(app)
-      cache_control.setup_max_age(64800)
+      cache_control.setup_max_age(604_800)
     end
 
     def self.cache_control_manager(app)

--- a/spec/cache_control_manager_spec.rb
+++ b/spec/cache_control_manager_spec.rb
@@ -32,13 +32,13 @@ describe HerokuDeflater::CacheControlManager do
     subject { described_class.new(rails_4_app) }
 
     it 'sets max age for static_cache_control config option' do
-      subject.setup_max_age(64800)
-      expect(rails_4_app.config.static_cache_control).to eq('public, max-age=64800')
+      subject.setup_max_age(3_600)
+      expect(rails_4_app.config.static_cache_control).to eq('public, max-age=3600')
     end
 
     it 'cache_control_headers returns cache control option' do
-      subject.setup_max_age(64800)
-      expect(subject.cache_control_headers).to eq('public, max-age=64800')
+      subject.setup_max_age(3_600)
+      expect(subject.cache_control_headers).to eq('public, max-age=3600')
     end
   end
 
@@ -51,13 +51,13 @@ describe HerokuDeflater::CacheControlManager do
     subject { described_class.new(rails_5_app) }
 
     it 'sets max age for public_file_server config option' do
-      subject.setup_max_age(64800)
-      expect(rails_5_app.config.public_file_server.headers['Cache-Control']).to eq('public, max-age=64800')
+      subject.setup_max_age(3_600)
+      expect(rails_5_app.config.public_file_server.headers['Cache-Control']).to eq('public, max-age=3600')
     end
 
     it 'cache_control_headers returns hash cache control headers' do
-      subject.setup_max_age(64800)
-      expect(subject.cache_control_headers).to eq(headers: { 'Cache-Control' =>'public, max-age=64800'})
+      subject.setup_max_age(3_600)
+      expect(subject.cache_control_headers).to eq(headers: { 'Cache-Control' =>'public, max-age=3600'})
     end
   end
 end


### PR DESCRIPTION
READY

It appears in this commit
https://github.com/romanbsd/heroku-deflater/commit/c3f238eeed284573c45ccbc6ff1aef7b4671b0b4#diff-b3f6914ce0fa17bf552de724de2332ed
that the default max-age was changed, I assume inadvertently, from a week (604,800) to 18 hours (64,800).  

This PR corrects that, adds an underscore in the integer for clarity, and touches some tests to help avoid a regression (changes `64800` to something visually very different, `3_600`)