### PR TITLE
use cache control headers set in config by user or cache_control method

### DIFF
--- a/lib/heroku-deflater/cache_control_manager.rb
+++ b/lib/heroku-deflater/cache_control_manager.rb
@@ -20,9 +20,9 @@ module HerokuDeflater
 
     def cache_control_headers
       if rails_version_5?
-        { 'Cache-Control' => cache_control }
+        { 'Cache-Control' => app.config.public_file_server.headers }
       else
-        cache_control
+        app.config.static_cache_control
       end
     end
 


### PR DESCRIPTION
cache control headers were previously being ignored, `cache_control_headers` consistently returned the default `:max_age`