### PR TITLE
Cache-Control header not set in Rails 5

### DIFF
--- a/lib/heroku-deflater/cache_control_manager.rb
+++ b/lib/heroku-deflater/cache_control_manager.rb
@@ -10,12 +10,6 @@ module HerokuDeflater
 
     def setup_max_age(max_age)
       @max_age = max_age
-      if rails_version_5?
-        app.config.public_file_server.headers ||= {}
-        app.config.public_file_server.headers['Cache-Control'] ||= cache_control
-      else
-        app.config.static_cache_control = cache_control
-      end
     end
 
     def cache_control_headers
@@ -33,7 +27,15 @@ module HerokuDeflater
     end
 
     def cache_control
-      @_cache_control ||= "public, max-age=#{max_age}"
+      @_cache_control ||= begin
+        default_cache_Control = "public, max-age=#{max_age}"
+        if rails_version_5?
+          app.config.public_file_server.headers ||= {}
+          app.config.public_file_server.headers['Cache-Control'] ||= default_cache_Control
+        else
+          default_cache_Control
+        end
+      end
     end
   end
 end

--- a/lib/heroku-deflater/cache_control_manager.rb
+++ b/lib/heroku-deflater/cache_control_manager.rb
@@ -14,28 +14,18 @@ module HerokuDeflater
 
     def cache_control_headers
       if rails_version_5?
-        { 'Cache-Control' => cache_control }
+        headers = app.config.public_file_server.headers ||= {}
+        headers['Cache-Control'] ||= "public, max-age=#{max_age}"
       else
-        cache_control
+        headers = app.config.static_cache_control
       end
+      headers
     end
 
     private
 
     def rails_version_5?
       Rails::VERSION::MAJOR >= 5
-    end
-
-    def cache_control
-      @_cache_control ||= begin
-        default_cache_Control = "public, max-age=#{max_age}"
-        if rails_version_5?
-          app.config.public_file_server.headers ||= {}
-          app.config.public_file_server.headers['Cache-Control'] ||= default_cache_Control
-        else
-          default_cache_Control
-        end
-      end
     end
   end
 end


### PR DESCRIPTION
OK I think I got it working this time. Tested on Heroku against my fork and the correct headers are there.

If you're using Cloudfront you'll have to invalidate any cached assets after deploying.

Fixes #39 