### PR TITLE
Compatibility with Rails 7.1

### DIFF
--- a/lib/heroku-deflater/serve_zipped_assets.rb
+++ b/lib/heroku-deflater/serve_zipped_assets.rb
@@ -1,6 +1,10 @@
 require 'action_controller'
-require 'active_support/core_ext/uri'
 require 'action_dispatch/middleware/static'
+
+if Rails::VERSION::MAJOR < 7
+  # Deprecated in Rails 7.0, and removed in 7.1
+  require 'active_support/core_ext/uri'
+end
 
 # Adapted from https://gist.github.com/guyboltonking/2152663
 #


### PR DESCRIPTION
Rails 7.0 deprecated `active_support/core_ext/uri`:
https://github.com/rails/rails/blob/v7.0.0/activesupport/lib/active_support/core_ext/uri.rb

And removed it in 7.1:
https://github.com/rails/rails/blob/v7.1.0/activesupport/lib/active_support/core_ext/uri.rb

This PR makes the library compatible with Rails 7.1, and removes the deprecation message with Rails 7.0.